### PR TITLE
fixes variables backupdir and tmpdir

### DIFF
--- a/dbbackup/dbb
+++ b/dbbackup/dbb
@@ -113,12 +113,12 @@ function is_interactive {
 
 function backup_file_handler {
 	# translate the vars to make it more readable
-	TMPDIR=$1
-	BACKUPDIR=$2
+	TMP_DIR=$1
+	BACKUP_DIR=$2
 	FILE=$3
 	# If enabled put out some debug infos
-	debug "TMPDIR: $TMPDIR"
-	debug "BACKUPDIR: $BACKUPDIR"
+	debug "TMP_DIR: $TMP_DIR"
+	debug "BACKUP_DIR: $BACKUP_DIR"
 	debug "FILE: $FILE"
 	# Check if the script should keep a filehistorie
 	if [ "$KEEP_BACKUP_FILES" = "TRUE" ]; then
@@ -132,46 +132,46 @@ function backup_file_handler {
 		debug "REMOVE_NUMBER: $REMOVE_NUMBER"
 		debug "FILE_PREFIX_NAME_TO_REMOVE: $FILE_PREFIX_NAME_TO_REMOVE-$FILE"
 		# Check there is an backupfile from the current day
-		if [ -f $BACKUPDIR/$BACKUP_DAY-$FILE ]; then
+		if [ -f $BACKUP_DIR/$BACKUP_DAY-$FILE ]; then
 			# If yes append miniutes and seconds to the date-profix of the filename
-			debug "File $BACKUPDIR/$BACKUP_DAY-$FILE already exists. Rename the new one."
+			debug "File $BACKUP_DIR/$BACKUP_DAY-$FILE already exists. Rename the new one."
 			DATE_TIME_SUFFIX=$(date +%H%M%S)
 			# ... and move it into the targetdir
-			mv $TMPDIR/$FILE $BACKUPDIR/$BACKUP_DAY-$DATE_TIME_SUFFIX-$FILE
+			mv $TMP_DIR/$FILE $BACKUP_DIR/$BACKUP_DAY-$DATE_TIME_SUFFIX-$FILE
 		else
 			# If there is no backupfile of the current day move it to the backupfolder
-			mv $TMPDIR/$FILE $BACKUPDIR/$BACKUP_DAY-$FILE
+			mv $TMP_DIR/$FILE $BACKUP_DIR/$BACKUP_DAY-$FILE
 		fi
 		# Check if there are files oder then the days to keep set in the config
-		if [ -f $BACKUPDIR/$FILE_PREFIX_NAME_TO_REMOVE-$FILE ]; then
+		if [ -f $BACKUP_DIR/$FILE_PREFIX_NAME_TO_REMOVE-$FILE ]; then
 			# if yes remove it
-			rm $BACKUPDIR/$FILE_PREFIX_NAME_TO_REMOVE-$FILE
+			rm $BACKUP_DIR/$FILE_PREFIX_NAME_TO_REMOVE-$FILE
 			# Also remove the files with the extended prefix in the name
 			# If there is ab file with the extende prefix then there has to be a file with tne normal prefix
-			rm $BACKUPDIR/$FILE_PREFIX_NAME_TO_REMOVE?????-$FILE
+			rm $BACKUP_DIR/$FILE_PREFIX_NAME_TO_REMOVE?????-$FILE
 		else
 			# If no file exists do nothing but some debuginfo
-			debug "File $BACKUPDIR/$FILE_PREFIX_NAME_TO_REMOVE-$FILE does not exists, so can not remove it."
+			debug "File $BACKUP_DIR/$FILE_PREFIX_NAME_TO_REMOVE-$FILE does not exists, so can not remove it."
 		fi
 	else
 		# If we do not keep a filehistory do thw following
 		# Check if the targefile exists
-		if [ -f $BACKUPDIR/$FILE ]; then
+		if [ -f $BACKUP_DIR/$FILE ]; then
 			debug "$FILE exists ... make a diff"
 			# Check if there are differences betwenn last backup and the actual one
-			diff $TMPDIR/$FILE $BACKUPDIR/$FILE > /dev/null 2>&1
+			diff $TMP_DIR/$FILE $BACKUP_DIR/$FILE > /dev/null 2>&1
 			if [ $? -ne 0 ]; then
 				# If yes then move it to the backupfolder
 				debug "Differences found between old and new $FILE -> moving to BACKUP_DIR"
-				mv $TMPDIR/$FILE $BACKUPDIR/$FILE
+				mv $TMP_DIR/$FILE $BACKUP_DIR/$FILE
 			else
 				# If not do nothing
 				debug "No differences found between old an new $FILE"
 			fi
 		else
 			# If there is a new databasedumpfile move it to the backupfolder
-			debug "New Backupfile $FILE -> moving to $BACKUPDIR"
-			mv $TMPDIR/$FILE $BACKUPDIR/$FILE
+			debug "New Backupfile $FILE -> moving to $BACKUP_DIR"
+			mv $TMP_DIR/$FILE $BACKUP_DIR/$FILE
 		fi
 	fi
 }


### PR DESCRIPTION
I used shellcheck to validate the script. There was inconsistency between the variables BACKUPDIR and BACKUP_DIR as well as TMPDIR and TMP_DIR. Replaced everything with BACKUP_DIR and TMP_DIR. Shellcheck said the variables in the init functions may be empty. Should now be fixed ;)